### PR TITLE
doc: add file-naming guidance (#4)

### DIFF
--- a/guidelines/general/file_names.md
+++ b/guidelines/general/file_names.md
@@ -1,0 +1,41 @@
+# File names
+
+> File names should match the thing they contain.
+
+## Examples
+
+| File contents                                 | File name                   |
+| --------------------------------------------- | --------------------------- |
+| A class, `ThingParser`                        | `ThingParser.js`            |
+| A component, `GizmoPicker`                    | `GizmoPicker.js`            |
+| A constructor function, `Blob`                | `Blob.js`                   |
+| A function, `concatenateStrings`              | `concatenateStrings.js`     |
+| Multiple exports, one of which is the default | Based on the default export |
+| Multiple exports, with no default             | Descriptive CamelCase       |
+| Tests for file `src/**/*.js`                  | `test/**/*.js`              |
+
+## File extensions
+
+In projects that use TypeScript, the same patterns apply, but with a ".ts" extension rather than ".js".
+
+In files that contain JSX, avoid custom extensions such as ".jsx" or ".tsx"; use ".js" or ".ts" instead. Our tooling should operate indistinctly of whether a file contains JSX, and this simplifies the task of writing globs that target source code.
+
+Historically, we used an additional ".es.js" in [liferay-portal](https://github.com/liferay/liferay-portal) to distinguish files that would be transpiled (and in which it was therefore safe to use "modern ES"). However, the current recommendation is to just use ".js", because our aim is to make transpilation transparent and uniform across all frontend code — for example, by moving JS out of JSPs — and the exceptions should be rare.
+
+## Questions?
+
+### How do I pick a "Descriptive CamelCase" name for my file with multiple exports but no default export?
+
+Choosing names is one of [two hard things](https://martinfowler.com/bliki/TwoHardThings.html), so it is not surprising that coming up with a name for a bundle of functionality may be difficult. One way to make the problem simpler is to follow these practices:
+
+-   Prefer small files that each export one thing as opposed to a large bundle that contains many things.
+-   One place where it is often appropriate to export many things is the file indicated by the "main" property in the "package.json": in this case, "index.js" is often a good name for this file.
+-   When creating a file with multiple exports is the most practical choice, pick a name that describes the purpose of the contents: if you cannot identify a single purpose, that is a sign that you should find a way to split the file.
+
+### Why `tests/**/*.js`?
+
+In practice, tooling can be configured to work well with alternatives like `__tests__/**/*.js`, `*-test.js` (etc), so in a sense the choice is arbitrary. We chose, however, to favor top-level "src/" and "test/" directories a long time ago in order to make it clear that code in the latter would never be bundled and delivered to clients.
+
+## Counterexamples
+
+-   Some third-party codebases distinguish component files by given them names of the form "Component.react.js".


### PR DESCRIPTION
This doesn't cover all the things yet (for example, it only talks about ".js" and ".ts"; it doesn't cover Sass or CSS or questions of folder structure, other than mentioning "src/" and "test/"), but it's a start.

Also, it is somewhat aspirational and recommendation-al (not an actual word) in nature, because it describes not how things are, but how I am suggesting we should work towards in the future; concretely, reality differs from what I've said here in three ways:

1. In liferay-portal, we currently use snake_case for files that export collections of things, and CamelCase for files that export constructors, classes, components etc.
2. In the Clay "develop" branch, we are using ".tsx" as an extension but I'm recommending ".ts" instead.
3. In some other repos on GitHub, we are using kebab-case in some filenames (eg. liferay-npm-tools).

So this is just to kick off discussion.

Closes: https://github.com/liferay/liferay-frontend-guidelines/issues/4