### PR TITLE
docs: fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Liferay Frontend Guidelines
 
-This is a live (changing) repository containing [guidelines](/guidelines) for doing Frontend Development at Liferay Inc.
+This is a live (changing) repository containing [general](/general) and [Liferay DXP-specific](/dxp) guidelines for doing Frontend Development at Liferay Inc.
 
 ## Guideline development
 


### PR DESCRIPTION
Fixes link that was broken in 520d67b.