### PR TITLE
feat: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Proposal.md
@@ -1,0 +1,16 @@
+---
+name: 💍 Proposal
+about: Issues for proposing a change to our frontend practices
+---
+
+<!--
+
+Before making a proposal, have you used the issue search functionality?
+
+-->
+
+## What is your proposal?
+
+## Why would adopting this proposal be beneficial?
+
+## What are the alternatives to this proposal?

--- a/.github/ISSUE_TEMPLATE/Proposal.md
+++ b/.github/ISSUE_TEMPLATE/Proposal.md
@@ -1,6 +1,7 @@
 ---
 name: 💍 Proposal
 about: Issues for proposing a change to our frontend practices
+labels: rfc
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,12 @@
+---
+name: 🤔 Question
+about: Issues for asking questions about our frontend practices
+---
+
+<!--
+
+Before posting a question, have you used the issue search functionality?
+
+-->
+
+## What is your question?

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,6 +1,7 @@
 ---
 name: 🤔 Question
 about: Issues for asking questions about our frontend practices
+labels: question
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/devDependency.md
+++ b/.github/ISSUE_TEMPLATE/devDependency.md
@@ -1,6 +1,7 @@
 ---
 name: 📦 devDependency
 about: Issues about adding new devDependencies
+labels: dev-dependency
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/devDependency.md
+++ b/.github/ISSUE_TEMPLATE/devDependency.md
@@ -1,0 +1,17 @@
+---
+name: 📦 devDependency
+about: Issues about adding new devDependencies
+---
+
+<!--
+
+For more info about adding a new devDependency,
+see dxp/dev_dependencies.md document in this repo.
+
+-->
+
+## What is the new or updated dependency?
+
+## Why is this dependency useful to you and others?
+
+## What are the alternatives?

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ This is a live (changing) repository containing [general](/general) and [Liferay
 We don't have a formalized procedure for implementation changes, but informally, we expect most changes to evolve like this:
 
 1.  Somebody submits a question (eg. an issue) or proposal (eg. could be an issue or PR).
-
-    If it's a question, tag it with the "[question](https://github.com/liferay/liferay-frontend-guidelines/labels/question)" label. If it's a proposal, tag it with "[rfc](https://github.com/liferay/liferay-frontend-guidelines/labels/rfc)" (which stands for "Request for comments").
-
 2.  Over a period of some days, we arrive at (or draw near to) a consensus.
 3.  After an interval that gives people adequate time to respond, we conclude the discussion; ultimately someone like [@jbalsas](https://github.com/jbalsas) will have the ability to make a call about what the conclusion should be (if it's not clear, or if there is some other reason to veto the consensus).
 

--- a/dxp/dev_dependencies.md
+++ b/dxp/dev_dependencies.md
@@ -23,8 +23,7 @@ Some of the reasons to "veto" arbitrary developer dependencies are:
 
 The best way to get a developer dependency approved for Liferay DXP is to prove its worth to your fellow frontends. To that end, please:
 
--   Head over to https://github.com/liferay/liferay-npm-tools and create a new issue
--   Prefix your issue title with `[dev:dependency]` like: - `[dev:dependency] Add Storybook` - `[dev:dependency] Update Eslint`
+-   Head over to https://github.com/liferay/liferay-npm-tools and [create a new issue](https://github.com/liferay/liferay-npm-tools/issues/new/choose) of type "devDependency".
 -   Present your case, explaining why this new or updated dependency is useful to you and probably to others
 -   Work with the team to present a proposal or find suitable alternatives
 

--- a/dxp/drag_and_drop.md
+++ b/dxp/drag_and_drop.md
@@ -4,7 +4,7 @@
 
 We are currently using the [react-dnd](https://www.npmjs.com/package/react-dnd) package in [liferay-portal](https://github.com/liferay/liferay-portal), and we provide a shared copy as part of the [frontend-js-react-web](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-react-web/package.json) package.
 
-We chose it because it powerful, flexible, and sufficiently low-level that it can be adapted to address all the use cases we've encountered so far. If you find a scenario in which it is lacking, please [open an issue](https://github.com/liferay/liferay-frontend-guidelines/issues/new) in the [liferay-frontend-guidelines](https://github.com/liferay/liferay-frontend-guidelines) repo so that we can evaluate how to best meet that use case.
+We chose it because it powerful, flexible, and sufficiently low-level that it can be adapted to address all the use cases we've encountered so far. If you find a scenario in which it is lacking, please [open an issue](https://github.com/liferay/liferay-frontend-guidelines/issues/new/choose) in the [liferay-frontend-guidelines](https://github.com/liferay/liferay-frontend-guidelines) repo so that we can evaluate how to best meet that use case.
 
 ### See also
 


### PR DESCRIPTION
This can probably be improved but adding some "seed" versions to get the ball rolling.

~~Still TODO (future): figure out how to auto-label issues based on the template used.~~

Replaces: https://github.com/liferay/liferay-frontend-guidelines/pull/23