### PR TITLE
docs: document liferay/liferay-binaries-cache-2020

### DIFF
--- a/dxp/environment.md
+++ b/dxp/environment.md
@@ -166,7 +166,26 @@ gradlew clean deploy -a
 
 ### Other useful `build.properties`
 
+#### JSP precompilation
+
+This setting may speed up builds by skipping ahead-of-time JSP precompilation:
+
 ```
-# Speed up builds by skipping JSP precompilation.
 jsp.precompile=off
 ```
+
+#### Gradle binaries cache
+
+This setting specifies a local clone of [the liferay/liferay-binaries-cache-2020 repo](https://github.com/liferay/liferay-binaries-cache-2020) to use as a cache of Gradle artifacts:
+
+```
+# This is the default; you can set it to an empty value to ignore the cache:
+build.binaries.cache.dir=../${build.binaries.cache.repository.name}
+```
+
+For example, if you cloned [liferay-portal](https://github.com/liferay/liferay-portal) in a directory called `portal/liferay-portal`, the above setting says the cache clone should exist at `portal/liferay-binaries-cache-2020`.
+
+Does the cache actually make the build faster?
+
+-   On a fast network, you probably won't notice any difference; if anything, if the cache is not already up-to-date when you start the build, you may actually notice a slowdown.
+-   On a slow network, having an up-to-date copy of the cache before you start is critical: it can make the difference between being able to finish the build at all, and it not finishing ever.

--- a/dxp/environment.md
+++ b/dxp/environment.md
@@ -188,4 +188,6 @@ For example, if you cloned [liferay-portal](https://github.com/liferay/liferay-p
 Does the cache actually make the build faster?
 
 -   On a fast network, you probably won't notice any difference; if anything, if the cache is not already up-to-date when you start the build, you may actually notice a slowdown.
--   On a slow network, having an up-to-date copy of the cache before you start is critical: it can make the difference between being able to finish the build at all, and it not finishing ever.
+-   On a slow network, it definitely makes a difference (although having an up-to-date copy of the cache before you start is critical). On bad connections, having the cache can make the difference between being able to finish the build at all, and it not finishing ever.
+
+For more details see "[How to Improve Build Time](https://grow.liferay.com/people?p_p_id=com_liferay_wiki_web_portlet_WikiPortlet&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_com_liferay_wiki_web_portlet_WikiPortlet_struts_action=%2Fwiki%2Fview&_com_liferay_wiki_web_portlet_WikiPortlet_redirect=%2Fpeople%3Fq%3Dbuild%2520&_com_liferay_wiki_web_portlet_WikiPortlet_pageResourcePrimKey=751906&p_r_p_http%3A%2F%2Fwww.liferay.com%2Fpublic-render-parameters%2Fwiki_nodeName=Grow&p_r_p_http%3A%2F%2Fwww.liferay.com%2Fpublic-render-parameters%2Fwiki_title=How+to+Improve+Build+Time#Clone-liferay-binaries-cache-2020)".


### PR DESCRIPTION
It's not clear that having the cache is always beneficial, although it sometimes is, so trying to reflect that in the documentation.