### PR TITLE
docs: Add reference to react-typescript-cheatsheet resource

### DIFF
--- a/general/typescript.md
+++ b/general/typescript.md
@@ -7,3 +7,5 @@ We are currently trialing [TypeScript](https://www.typescriptlang.org/) in [the 
 In the future we will [evaluate the possibility](https://github.com/liferay/liferay-frontend-guidelines/issues/37) of using TypeScript directly inside liferay-portal.
 
 For other projects, we should weigh up the relative costs and benefits of using TypeScript. For example, in projects that don't have build processes — examples include [liferay-js-themes-toolkit](https://github.com/liferay/liferay-js-themes-toolkit) and [liferay-npm-tools](https://github.com/liferay/liferay-npm-tools) — we've found that the ability to iterate and debug in-place (even inside the "node_modules") has been a useful debugging workflow that would be made more difficult if we switched to TypeScript, so we've stayed with untranspiled vanilla JavaScript so far.
+
+When using Typescript and React, check out [react-typescript-cheatsheet](https://github.com/typescript-cheatsheets/react-typescript-cheatsheet) for helpful tips.


### PR DESCRIPTION
I found this repo recently and it was pretty helpful to see other examples of TS + react. I thought it would be helpful for us to provide a link for additional resoruces.

Also, the maintainers are pretty active, so thats a plus.