### PR TITLE
fix: make globs work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
 	"repository": "https://github.com/liferay/liferay-frontend-guidelines.git",
 	"scripts": {
 		"ci": "yarn format:check && yarn lint && yarn test",
-		"format": "prettier --write '**/{.,}*.js{,on}' '**/*.md'",
-		"format:changed": "git ls-files -mz -- '*.js' '*.json' '*.md' | xargs -0 prettier --write --",
-		"format:check": "prettier --list-different '**/{.,}*.js{,on}' '**/*.md'",
-		"lint": "eslint '**/*.js'",
-		"lint:fix": "eslint --fix '**/*.js'",
+		"format": "prettier --write \"**/{.,}*.js{,on}\" \"**/*.md\"",
+		"format:changed": "git ls-files -mz -- \"*.js\" \"*.json\" \"*.md\" | xargs -0 prettier --write --",
+		"format:check": "prettier --list-different \"**/{.,}*.js{,on}\" \"**/*.md\"",
+		"lint": "eslint \"**/*.js\"",
+		"lint:fix": "eslint --fix \"**/*.js\"",
 		"test": "node support/checkLinks.js"
 	},
 	"version": "0.0.1"


### PR DESCRIPTION
Analogous change to this one on the alloy-editor repo:

https://github.com/liferay/alloy-editor/pull/1374

Just in case anybody is ever foolhardy enough to try doing development on this repo on Windows.