### PR TITLE
 docs: add build status badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # Based on: https://github.com/actions/starter-workflows/blob/master/ci/node.js.yml
 
-name: Node.js CI
+name: ci
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Liferay Frontend Guidelines
 
+![](https://github.com/liferay/liferay-frontend-guidelines/workflows/ci/badge.svg)
+
 This is a live (changing) repository containing [general](/general) and [Liferay DXP-specific](/dxp) guidelines for doing Frontend Development at Liferay Inc.
 
 ## Guideline development


### PR DESCRIPTION
Renames "Node.js CI" to "ci" and adds a badge showing status to the README.