### PR TITLE
fix: teach checkLinks.js to handle more heading and link types

### DIFF
--- a/support/checkLinks.js
+++ b/support/checkLinks.js
@@ -176,6 +176,11 @@ function extractLinks(contents, file) {
 			links.add(link);
 			return ' ';
 		})
+		// [link text](<https://example.com>)
+		.replace(/\[[^\]\n]+\]\(<([^\s>]+)>\)/g, (_, link) => {
+			links.add(link);
+			return ' ';
+		})
 		// [link text](https://example.com)
 		.replace(/\[[^\]\n]+\]\(([^\s)]+)\)/g, (_, link) => {
 			links.add(link);

--- a/support/checkLinks.js
+++ b/support/checkLinks.js
@@ -52,8 +52,8 @@ async function checkInternal(link, files) {
 		const targets = new Set();
 
 		contents.replace(/^#+\s+(.+?)\s*$/gm, (match, heading) => {
-			// To make a title anchor, GitHub:
-			// - Extracts link targets from Markdown links.
+			// To make a target anchor, GitHub:
+			// - Extracts link text from Markdown links.
 			// - Turns spaces, hyphens, commas into hyphens.
 			// - Removes backticks, colons.
 			const target = heading


### PR DESCRIPTION
As discussed [here](https://github.com/liferay/liferay-frontend-guidelines/pull/140#discussion_r402427606), we have some more challenging heading and link types to handle in that doc; eg.

- Headings with colons.
- Headings with backticks.
- Headings with links.
- Combinations of the above.
- Links whose case doesn't match the case of the GitHub-generated anchor.
- Links that use a novel angle-bracket syntax (eg. `[text](<http://example.com>)`).

Examples:

    Headings:

    ### [`EditorConfigContributor`](https://github.com/liferay/liferay-portal/blob/61601e89b64240db742eceaf82e86460620bcd97/portal-kernel/src/com/liferay/portal/kernel/editor/configuration/EditorConfigContributor.java#L105-L130)

    #### `public String getResourcesJspPath`

    Links:

    of the new [JavaScript APIs](#JavaScript)

    (actual anchor is #javascript)

    [text](<http://example.com>)