### PR TITLE
docs: fix broken Markdown link

### DIFF
--- a/dxp/architecture/rich_text_editors.md
+++ b/dxp/architecture/rich_text_editors.md
@@ -143,7 +143,7 @@ As we're moving towards a single editor module, here's a detailed explanation of
 
 ### Java Services
 
-As stated in the [Java](#Java) section, one of the most important Services in Rich Text Editor modules are the public implementations of [`EditorRenderer`](https://github.com/liferay/liferay-portal/blob/61601e89b64240db742eceaf82e86460620bcd97/modules/apps/frontend-editor/frontend-editor-api/src/main/java/com/liferay/frontend/editor/EditorRenderer.java#L20-L32.
+As stated in the [Java](#Java) section, one of the most important Services in Rich Text Editor modules are the public implementations of [`EditorRenderer`](https://github.com/liferay/liferay-portal/blob/61601e89b64240db742eceaf82e86460620bcd97/modules/apps/frontend-editor/frontend-editor-api/src/main/java/com/liferay/frontend/editor/EditorRenderer.java#L20-L32).
 
 This module exposes the following `EditorRenderer` implementations:
 


### PR DESCRIPTION
Didn't notice while reviewing the Markdown source in [#140](https://github.com/liferay/liferay-frontend-guidelines/pull/140) but caught it while looking at [the final result](https://github.com/liferay/liferay-frontend-guidelines/blob/d1233ead83a8b8de776175fbc11da8e99f53267a/dxp/architecture/rich_text_editors.md).