### PR TITLE
docs: add links to Liferay-specific editor integration info

### DIFF
--- a/dxp/formatting.md
+++ b/dxp/formatting.md
@@ -4,7 +4,9 @@ Please, read our [General Formatting Guidelines](../general/formatting.md) for a
 
 [Prettier](https://prettier.io/) usage is built-in inside [Liferay DXP](https://github.com/liferay/liferay-portal) thanks to the [`liferay-npm-scripts`](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts) package that encapsulates all the necessary logic, dependencies and configuration for it to work.
 
-> Only JavaScript and SCSS files are formatted using Prettier
+> Only JSP, JavaScript and SCSS files are formatted using Prettier
+
+Note that because we apply some small Liferay-specific overrides to Prettier's behavior when formatting in [liferay-portal](https://github.com/liferay/liferay-portal), please see the [editor integrations information](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts#editor-integrations) for details on how to set up your editor or IDE to apply these overrides automatically.
 
 Every module inside [Liferay DXP](https://github.com/liferay/liferay-portal) with JavaScript or SCSS files should contain a `package.json` file with at least the following npm scripts:
 

--- a/general/formatting.md
+++ b/general/formatting.md
@@ -58,6 +58,8 @@ Please, read the [Liferay DXP Formatting Guidelines](../dxp/formatting.md) for s
 
 Install the [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension and use the usage option that better suits you.
 
+When working inside [liferay-portal](https://github.com/liferay/liferay-portal), there is some [custom integration](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts#editor-integrations) that you may wish to apply in order to have it automatically apply some minor overrides to Prettier's standard styling that are required by Liferay.
+
 ### IntelliJ IDEA
 
 If you're an [IntelliJ IDEA](https://plugins.jetbrains.com/) user, you can use this [Prettier plugin](https://plugins.jetbrains.com/plugin/10456-prettier) to format your JavaScript and SCSS files.


### PR DESCRIPTION
As pointed out [here](https://github.com/markocikos/liferay-portal/pull/188#issuecomment-635818859), the info here was stale and did not reflect [the latest editor integration guidelines](https://github.com/liferay/liferay-npm-tools/tree/master/packages/liferay-npm-scripts#editor-integrations).

Rather than copy them here (and risk them getting out of sync), I just linked to them.

Note: CI is going to fail on this because CloudFlare has decided to 503 the link verification requests (again). I'll fix that in a separate pull.