### PR TITLE
docs: add some additional notes on file naming (constants)

### DIFF
--- a/general/file_names.md
+++ b/general/file_names.md
@@ -4,15 +4,16 @@
 
 ## Examples
 
-| File contents                                 | File name                   |
-| --------------------------------------------- | --------------------------- |
-| A class, `ThingParser`                        | `ThingParser.js`            |
-| A component, `GizmoPicker`                    | `GizmoPicker.js`            |
-| A constructor function, `Blob`                | `Blob.js`                   |
-| A function, `concatenateStrings`              | `concatenateStrings.js`     |
-| Multiple exports, one of which is the default | Based on the default export |
-| Multiple exports, with no default             | Descriptive CamelCase       |
-| Tests for file `src/**/*.js`                  | `test/**/*.js`              |
+| File contents                                 | File name                             |
+| --------------------------------------------- | ------------------------------------- |
+| A class, `ThingParser`                        | `ThingParser.js`                      |
+| A component, `GizmoPicker`                    | `GizmoPicker.js`                      |
+| A constructor function, `Blob`                | `Blob.js`                             |
+| A function, `concatenateStrings`              | `concatenateStrings.js`               |
+| A dictionary of constants, `EVENT_TYPES`      | `EVENT_TYPES.js` (but see note below) |
+| Multiple exports, one of which is the default | Based on the default export           |
+| Multiple exports, with no default             | Descriptive CamelCase                 |
+| Tests for file `src/**/*.js`                  | `test/**/*.js`                        |
 
 ## File extensions
 
@@ -21,6 +22,33 @@ In files that contain JSX, avoid custom extensions such as ".jsx"; just use ".js
 In projects that use TypeScript, the same patterns apply, but with a ".ts" extension rather than ".js". But note one distinction: TypeScript files containing JSX must use the ".tsx" extension [in order for the TypeScript compiler to process the JSX](https://github.com/liferay/liferay-frontend-guidelines/issues/24).
 
 Historically, we used an additional ".es.js" in [liferay-portal](https://github.com/liferay/liferay-portal) to distinguish files that would be transpiled (and in which it was therefore safe to use "modern ES"). However, the current recommendation is to just use ".js", because our aim is to make transpilation transparent and uniform across all frontend code — for example, by moving JS out of JSPs — and the exceptions should be rare.
+
+### What about `EVENT_TYPES.js` versus `eventTypes.js`?
+
+We started this document with a simple rule — "File names should match the thing they contain" — so it's clear that we _should_ use a name like `EVENT_TYPES.js` for a file that exports a map of constants, `EVENT_TYPES`.
+
+However, in liferay-portal, for now, we must note the strong historical tendency to avoid uppercase filenames (with rare exceptions like [CONTRIBUTING.markdown](https://github.com/liferay/liferay-portal/blob/master/CONTRIBUTING.markdown) and [README](https://github.com/liferay/liferay-portal/blob/master/README.markdown)):
+
+-   `find . -name '*.js' -not -path '*/node_modules/*' -not -path '*/build/*' -not -path '*/classes/*' | egrep '[A-Z]{3}.js'` returns 4 results, [all of which](https://gist.github.com/wincent/107920ea1d9bf033d827fabfdebc7fda) are file names that contain acronyms like `URL` and `HTML`.
+-   `find . -name '*.js' -not -path '*/node_modules/*' -not -path '*/build/*' -not -path '*/classes/*' | wc -l` shows that this is a minuscule proportion out of the remaining 6,748 ".js" files in liferay-portal.
+
+As such, we also allow lower CamelCase for files that export a dictionary of constants, as seen extensively used in [this directory](https://github.com/liferay/liferay-portal/tree/0ad5213737fced46e62e46d414a44b3bdc515a9d/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants), such as in the file [`itemTypes.js`](https://github.com/liferay/liferay-portal/blob/0ad5213737fced46e62e46d414a44b3bdc515a9d/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants/itemTypes.js) which has a named `ITEM_TYPES` export. Also note that even though those files only export a single object, it is _not_ the `default` export, so as to force people to consistently use the same name for the imported object:
+
+```js
+import {ITEM_TYPES} from './itemTypes';
+```
+
+In all other cases where the file name can match the default export (eg. classes, components, constant dictionaries outside of liferay-portal, constructor functions, other functions), the risk of using an discrepant name is less, so we prefer to use default exports:
+
+```js
+import CakeRecipe from './CakeRecipe'; // class
+import IngredientsList from './IngredientsList'; // component
+import OVEN_PRESETS from './OVEN_PRESETS'; // constants
+import Tray from './Tray'; // constructor function
+import preheatOven from './preheatOven'; // other function
+```
+
+In the future, we would like to remove this source of inconsistency by moving towards standard file-naming patterns in liferay-portal.
 
 ## Questions?
 


### PR DESCRIPTION
Seeing as this came up [in review here](https://github.com/liferay-frontend/liferay-portal/pull/48#discussion_r450509707) I thought we may as well document it. Specifically, the question is how to name a file that exports a bunch of constants.

We have a tension between what our simple rule ("file names should match their contents") would imply, and what we are actually doing in liferay-portal.

So, given that this document is somewhat aspirational in nature (ie. describing what we should do even if it doesn't yet match what we actually do), I've noted that we should be doing (use all caps in the name) and also what we tend to do in liferay-portal up to today... Maybe one day we will be able to change this.

Note that there are still two approaches to defining constants that we could debate, but given that we currently seem to be doing it the same way (the first one), I didn't get into that in this PR:

1.  Export default object:

    ```js
    // in COLORS.js:
    const BLUE = '#00f';
    const GREEN = '#0f0';
    const RED = '#f00';

    export default COLORS = {BLUE, GREEN, RED};

    // or:
    const COLORS = {BLUE, GREEN, RED};
    export default COLORS;

    // or even:
    export default {BLUE, GREEN, RED};

    // in other.js:
    import COLORS from './COLORS';
    ```

2.  Export individual items:

    ```js
    // in COLORS.js:
    export const BLUE = '#00f';
    export const GREEN = '#0f0';
    export const RED = '#f00';

    // in other.js:
    import * as COLORS from './COLORS';
    ```