### PR TITLE
docs: relate <aui:script> to Aggregate Filter

### DIFF
--- a/dxp/resource_serving.md
+++ b/dxp/resource_serving.md
@@ -117,6 +117,8 @@ Once the locale is determined, it replaces each occurrence of `Liferay.Language.
 
 This filter is used to bundle multiple JavaScript files into a minified single resource (called bundle) that can be fetched from the server, as well as to minify single JavaScript or CSS files.
 
+In addition, it also gathers all JavaScript code contained in `<aui:script>` tags (and not marked inline) into a single block of code that is written at the end of the page.
+
 #### JavaScript Bundle
 
 > ⚠ This is a deprecated mechanism, though it still works if someone configures it. ⚠


### PR DESCRIPTION
As per [this PR](https://github.com/liferay/liferay-frontend-guidelines/blob/b92822feab6d29b77ee1af9b98be61cc30a8cd4e/dxp/aui_script.md#inline-js-on-the-jsp) explain how `AggregateFilter` also consolidates all `<aui:script>` code into one single block.